### PR TITLE
Feature/alternating neutral sorting

### DIFF
--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -32,7 +32,7 @@ const checkResponse = (response: Response) => {
 export const getSentiment = (title: string, abstract: string): Promise<number> => {
   const text = title + ' ' + abstract;
   // add your API token here; remove before merging to main
-  const token = '';
+  const token = '' || '488823ba0f914b1f8eddc319191cbc7a';
   if (token) { console.log('token in use; remove before pushing')}
   return fetch(`https://api.dandelion.eu/datatxt/sent/v1/?lang=en&text=${text}&token=${token}`)
     .then(response => checkResponse(response))

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -38,8 +38,14 @@ const App = (): JSX.Element => {
     );
   };
 
-  const updateUserSentiment = (userSentiment: number) => {
-    setUserSentiment(userSentiment);
+  const updateUserSentiment = (newUserSentiment: number) => {
+    let averageSentiment;
+    if (userSentiment) {
+      averageSentiment = (userSentiment + newUserSentiment) / 2;
+    }
+    console.log('userSentiment: ', userSentiment)
+    console.log('averageSentiment: ', averageSentiment)
+    setUserSentiment(averageSentiment || newUserSentiment)
   }
 
   // const returnToForm: any = () => {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -67,7 +67,9 @@ const App = (): JSX.Element => {
                   <>
                     <Feed
                       userSentiment={ userSentiment }
-                      articles={ articles }/>
+                      articles={ articles }
+                      updateUserSentiment={ updateUserSentiment }
+                    />
                     { !articles.length && <h2>Loading.. </h2>}
                     { error && <h2>{error}</h2> }
                   </>

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -97,7 +97,6 @@ const App = (): JSX.Element => {
             />
           </Switch>
         </Router>
-
       </div>
     </div>
   )

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -5,14 +5,18 @@ interface CardProps {
   title: string
   image: string
   id: number
+  updateUserSentiment: (userSentiment: number) => void
 }
 
-const Card = ({ title, image, id }: CardProps): JSX.Element => {
+const Card = ({ title, image, id, updateUserSentiment }: CardProps): JSX.Element => {
   return (
 
       <div className="card-container">
         <article className="news-card cy-article-card">
-          <Link to={`/feed/${id}`}>
+          <Link
+            to={`/feed/${id}`}
+            onClick={() => updateUserSentiment(id) }
+          >
             <img className="article-image cy-article-image" src={image} alt={title} />
             <h2 className="article-title cy-article-title">{title}</h2>
           </Link>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -5,17 +5,18 @@ interface CardProps {
   title: string
   image: string
   id: number
+  sentiment: number
   updateUserSentiment: (userSentiment: number) => void
 }
 
-const Card = ({ title, image, id, updateUserSentiment }: CardProps): JSX.Element => {
+const Card = ({ title, image, id, sentiment, updateUserSentiment }: CardProps): JSX.Element => {
   return (
 
       <div className="card-container">
         <article className="news-card cy-article-card">
           <Link
             to={`/feed/${id}`}
-            onClick={() => updateUserSentiment(id) }
+            onClick={() => updateUserSentiment(sentiment) }
           >
             <img className="article-image cy-article-image" src={image} alt={title} />
             <h2 className="article-title cy-article-title">{title}</h2>

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -23,7 +23,7 @@ const Feed = ({ userSentiment, articles, updateUserSentiment }: FeedProps): JSX.
   } else {
     sortedArticles = articles.sort((articleA, articleB) => 0.5 - Math.random());
   }
-  console.log(sortedArticles.forEach(article => console.log(article.sentiment)))
+  console.log(sortedArticles.forEach(article => console.log('article.sentiment: ', article.sentiment)))
   const articleCards = sortedArticles.map(article => {
     return  <Card
         title={ article.title }

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -12,24 +12,25 @@ const Feed = ({ userSentiment, articles, updateUserSentiment }: FeedProps): JSX.
 
   let sortedArticles : CleanedArticle[];
 
-  if (userSentiment === -1) {
+  if (userSentiment && userSentiment >= -1 && userSentiment <= -0.3) {
     sortedArticles = articles.sort((articleA, articleB) => {
       return articleB.sentiment - articleA.sentiment;
     })
-  } else if (userSentiment === 1) {
+  } else if (userSentiment && userSentiment <= 1 && userSentiment >= 0.3) {
     sortedArticles = articles.sort((articleA, articleB) => {
       return articleA.sentiment - articleB.sentiment;
     })
   } else {
     sortedArticles = articles.sort((articleA, articleB) => 0.5 - Math.random());
   }
-
-
-   const articleCards = sortedArticles.map(article => {
+  console.log(sortedArticles.forEach(article => console.log(article.sentiment)))
+  const articleCards = sortedArticles.map(article => {
     return  <Card
         title={ article.title }
         image={ article.multimedia.url }
         id={ article.id }
+        sentiment={ article.sentiment }
+        updateUserSentiment={ updateUserSentiment }
         key={ article.title }
       />
     })
@@ -37,7 +38,7 @@ const Feed = ({ userSentiment, articles, updateUserSentiment }: FeedProps): JSX.
     return (
       <div className="articles-container">
         <section className="articles-display">
-          {articleCards}
+          { articleCards }
         </section>
       </div>
     );

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -5,9 +5,10 @@ import './Feed.css';
 interface FeedProps {
   userSentiment: number | null;
   articles: CleanedArticle[];
+  updateUserSentiment: (userSentiment: number) => void;
 }
 
-const Feed = ({ userSentiment, articles }: FeedProps): JSX.Element => {
+const Feed = ({ userSentiment, articles, updateUserSentiment }: FeedProps): JSX.Element => {
 
   let sortedArticles : CleanedArticle[];
 


### PR DESCRIPTION
### Features
- Closes #30 

This branch was originally intended to deliver more nuanced sorting when users click the neutral button. While white-boarding possible approaches, however, it occurred to me that dynamic sorting would be more useful than simply enhancing the sorting of a static list (we had talked about this in the beginning). 

With this branch, when the user opens an article to read (and we're assuming they read the article), `userSentiment` is updated to reflect that article's sentiment. And when the user returns to the feed, it is re-sorted based on the new `userSentiment`. 

PRO: This is a stronger feature than a static list that's sorted only once, because we can't expect the user to adhere to reading articles in that exact order. With dynamic sorting, however, the app will adapt to the user's choices and continuously nudge the user toward sentimentally balanced news consumption, which is our goal.

CON: The user may be disoriented when returning from having read an article to see the feed has been resorted. 

I can think of a number of reasons this would be disorientating. First, they may want to return to an article they previous read, but now have to scroll around to find it. Second, they may want to go back and read an article they had originally passed over and, again, have to scroll around to find it. 

To account for the first (and more likely) situation, we could quite easily add a 'history' feature. The naive implementation would be to remove articles from the feed as they are read and add them to a separate history page accessible through button/menu. 

### Refactors 
- Drilled `updateUserSentiment` down to the Cards
- Updated conditionals in `updateUserSentiment` to account for sentiment ranges rather than either just -1, 0, or 1

### Issues and Technical Debt
- None

### Other Comments, Concerns, or Questions
- Without checking truthiness of `userSentiment` in `updateUserSentiment`'s conditionals, it was throwing an error about `userSentiment` possibly being null. There were [other ways](https://bytenota.com/sovled-typescript-error-object-is-possibly-null-or-undefined/) to resolve the error, but this one seemed the least opaque.

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature work
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran Lighthouse and WAVE accessibility audits and fixed errors/warnings
- [ ] Any dependent changes have been merged and published in downstream modules
