### PR TITLE
Cypress/article view

### DIFF
--- a/cypress/integration/Article_spec.js
+++ b/cypress/integration/Article_spec.js
@@ -1,0 +1,52 @@
+describe('Article', () => {
+  beforeEach(() => {
+    cy.intercept("https://api.nytimes.com/svc/topstories/v2/home.json?api-key=GKUzDD1VY9ssjZ1AGusX3ci6AeoXCaSr", {fixture: 'nyt-article-fetch.json'})
+      .intercept('https://api.dandelion.eu/datatxt/sent/v1/?lang=en&text=A new biography by Debby Applegate recounts the story of Polly Adler, who arrived in America from Russia at 13 and became New Yorks most successful brothel owner, befriending mobsters, policemen, politicians and writers&token=beb0091844524790b7672a69bac06a2a', {fixture: 'manhattan-madam-sentiment.json'})
+      .intercept('https://api.dandelion.eu/datatxt/sent/v1/?lang=en&text=The magazines Ethicist columnist on responding to infidelity&token=beb0091844524790b7672a69bac06a2a', {fixture: 'affair-sentiment.json'})
+
+    cy.visit('/')
+      .get('.cy-sad-btn').click()
+      .url().should('include', '/feed')
+      .get('.cy-article-link').first().click()
+  })
+
+  it('Should display the article title', () => {
+    cy.get('.cy-single-article-title').contains('The Manhattan ‘Madam’ Who Hobnobbed With the City’s Elite')
+  })
+
+  it('Should display the article image and its caption', () => {
+    cy.get('.cy-single-article-image').should('have.attr', 'src', 'https://static01.nyt.com/images/2021/10/25/books/review/00Bren/00Bren-superJumbo.jpg')
+
+    cy.get('.cy-single-article-caption').contains('Polly Adler exiting a police van after being arrested in 1936. The more successful Polly’s brothel became, the more hounded she was — by the police, by Tammany Hall, by the Broadway mob.')
+  })
+
+  it('Should display the article abstract', () => {
+    cy.get('.cy-single-article-abstract').contains('A new biography by Debby Applegate recounts the story of Polly Adler, who arrived in America from Russia at 13 and became New Yorks most successful brothel owner, befriending mobsters, policemen, politicians and writers')
+  })
+
+  it('Should display placeholder text', () => {
+    cy.get('p').eq(1).contains('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
+  })
+
+  it('Should have Back link to return to the feed', () => {
+    cy.get('.cy-back-link').click()
+      .url().should('eq', 'http://localhost:3000/feed')
+  })
+
+
+})
+
+describe('Article Error', () => {
+  beforeEach(() => {
+    cy.visit('/feed/999999999')
+  })
+
+  it('Should display a helpful error message', () => {
+    cy.get('.cy-error-message').contains('No match for')
+  })
+
+  it('Should display a button to redirect back to feed', () => {
+    cy.get('.cy-feed-link').click()
+      .url().should('eq', 'http://localhost:3000/feed')
+  })
+})

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -5,6 +5,7 @@ import { CleanedArticle } from '../../Models';
 import Form from '../Form/Form';
 import Feed from '../Feed/Feed';
 import Article from '../Article/Article';
+import NoMatch from '../NoMatch/NoMatch';
 import './App.css';
 
 const App = (): JSX.Element => {
@@ -102,9 +103,12 @@ const App = (): JSX.Element => {
                       key={ singleArticle.title }
                     />
                   )
+                } else {
+                  return <NoMatch />
                 }
               }}
             />
+            <Route path="*" component={NoMatch} />
           </Switch>
         </Router>
       </div>

--- a/src/components/Article/Article.tsx
+++ b/src/components/Article/Article.tsx
@@ -15,16 +15,16 @@ const Article = ({ title, image, abstract, caption }: ArticleProps): JSX.Element
   return (
     <section className="single-article-container">
       <div className="back-button-container">
-        <Link to="/feed">
+        <Link to="/feed" className="cy-back-link">
           ⇦ BACK
         </Link>
       </div>
       <figure>
-        <img src={image} alt={caption} className="single-article-image"/>
-        <figcaption className="single-article-caption">{caption}</figcaption>
+        <img src={image} alt={caption} className="single-article-image cy-single-article-image"/>
+        <figcaption className="single-article-caption cy-single-article-caption">{caption}</figcaption>
       </figure>
-      <h2 className="single-article-title">{title}</h2>
-      <p>{abstract}</p>
+      <h2 className="single-article-title cy-single-article-title">{title}</h2>
+      <p className="cy-single-article-abstract">{abstract}</p>
       <p>{placeholderText}</p>
       <p>{placeholderText}</p>
       <p>{placeholderText}</p>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -17,6 +17,7 @@ const Card = ({ title, image, id, sentiment, updateUserSentiment }: CardProps): 
           <Link
             to={`/feed/${id}`}
             onClick={() => updateUserSentiment(sentiment) }
+            className="cy-article-link"
           >
             <img className="article-image cy-article-image" src={image} alt={title} />
             <h2 className="article-title cy-article-title">{title}</h2>

--- a/src/components/NoMatch/NoMatch.tsx
+++ b/src/components/NoMatch/NoMatch.tsx
@@ -1,0 +1,19 @@
+import { Link, useLocation } from 'react-router-dom'
+import './NoMatch.css'
+
+const NoMatch = (): JSX.Element => {
+  const location = useLocation();
+  console.log(location, "is this running")
+  return (
+    <div>
+      <h3 className="cy-error-message">
+        No match for <code>{location.pathname}</code>
+      </h3>
+      <Link to="/feed" className="cy-feed-link">
+        Back to Feed
+      </Link>
+    </div>
+  );
+}
+
+export default NoMatch


### PR DESCRIPTION
### Features
- Closes #43
- Closes #36 
- Created NoMatch component.

### Refactors 
- Added class names for cypress tests in both Article and Card components.
- Updated Routes to include NoMatch component

### Issues and Technical Debt
- NA

### Other Comments, Concerns, or Questions
- We can change what the NoMatch component displays. I based it off of the example provided by [here](https://v5.reactrouter.com/web/example/no-match).

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature work
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran Lighthouse and WAVE accessibility audits and fixed errors/warnings
- [ ] Any dependent changes have been merged and published in downstream modules
