### PR TITLE
Resize elements in individual article view

### DIFF
--- a/src/components/Article/Article.css
+++ b/src/components/Article/Article.css
@@ -1,5 +1,6 @@
 
 .single-article-container {
+  margin-top: 2rem;
   max-width: 80vw;
   display: flex;
   flex-direction: column;
@@ -27,7 +28,7 @@
 
 .single-article-image {
   height: auto;
-  width: 50%;
+  width: 65%;
   margin-top: .5rem;
   border: 1px solid white;
   box-shadow: 2px 2px 2px black;
@@ -58,4 +59,25 @@
   margin-left: 10%;
   margin-right: 10%;
   text-align: left;
+}
+
+@media (max-width: 900px) {
+  .single-article-image {
+    width: 90%;
+  }
+
+  .single-article-container {
+    max-width: 88vw;
+  }
+
+  .single-article-caption {
+    font-size: 1rem;
+  }
+
+  .single-article-container > p {
+    color: white;
+    margin-left: 3%;
+    margin-right: 3%;
+    text-align: left;
+  }
 }

--- a/src/components/Feed/Feed.css
+++ b/src/components/Feed/Feed.css
@@ -56,21 +56,16 @@
   text-decoration: none;
 }
 
-@media (max-width: 1600px) {
-  .header-elements-container {
-    margin-top: .6%;
-  }
-}
 
 @media (max-width: 1150px) {
   .header-elements-container {
-    margin-top: 1.2%;
+    margin-top: 1.5%;
   }
 }
 
 @media (max-width: 1000px) {
   .header-elements-container {
-    margin-top: 1%;
+    margin-top: 2%;
   }
 
   .articles-display {
@@ -80,7 +75,7 @@
 
 @media (max-width: 900px) {
   .header-elements-container {
-    margin-top: 0%;
+    margin-top: 1%;
   }
 
   .articles-display {
@@ -88,11 +83,11 @@
   }
 
   .header {
-    height: 3.2rem;
+    height: 10%;
   }
 
   .header-txt,
-  .header-text-2 {
+  .header-txt-2 {
     font-size: 2rem;
   }
 
@@ -120,6 +115,10 @@
 }
 
 @media (max-width: 630px) {
+  .header-elements-container {
+    margin-top: 0px;
+  }
+
   .articles-display {
     margin-top: 1rem;
   }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -10,6 +10,7 @@
 .header-elements-container {
   position: relative;
   display: flex;
+  flex-direction: column;
   width: 58%;
 }
 


### PR DESCRIPTION
### Features
- N/A

### Refactors 
- Re-sized elements in individual article view via media queries
- Fixed typo that caused the 'News' in 'WellNews' to suddenly shrink at lower screen sizes
- Made small adjustments to header margin in media queries

### Issues and Technical Debt
- N/A

### Other Comments, Concerns, or Questions
- In an ideal world I would redo the header CSS to stay centered irrespective of screen size, but alas, we need to turn this in at some point.

### Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature work
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran Lighthouse and WAVE accessibility audits and fixed errors/warnings
- [ ] Any dependent changes have been merged and published in downstream modules
